### PR TITLE
fix: add openresolv dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM louislam/uptime-kuma:1.23.11-debian as base-image
 
 RUN echo "deb http://deb.debian.org/debian buster-backports main non-free" >> /etc/apt/sources.list
 RUN apt update && apt upgrade -y
-RUN apt install -y wireguard htop iperf3 iputils-ping iproute2 net-tools dnsutils dumb-init
+RUN apt install -y wireguard htop iperf3 iputils-ping iproute2 net-tools dnsutils dumb-init openresolv
 
 COPY /root /
 


### PR DESCRIPTION
First, thanks for the good work

I was having when settings DNS on the wg0.conf file

`/usr/bin/wg-quick:` line 32: resolvconf: command not found`

But I found out that by installing openresolv, that problem whas fixed